### PR TITLE
Provide options to filter out pseudo dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@1.3.0
+
+      - name: lint
+        run: vendor/bin/phpstan analyse -n --no-progress -c phpstan.neon src/
+
+  phpmd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@1.3.0
+
+      - name: PHPMD
+        run: vendor/bin/phpmd src/ ansi phpmd.xml --exclude vendor/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Composer Dependency Ignore
+
+This composer plugin allows for some dependencies to be ignored during
+installation and update.
+
+## Usage
+
+Install the composer plugin via composer.
+
+```bash
+composer require prograp/composer-dependency-ignore
+```
+
+Add dependencies to your ignore list in your `composer.json`.
+```JSON
+{
+    "extra": {
+        "ignore": [
+            "vendor/package-1",
+            "vendor/package-2"
+        ]
+    }
+}
+```
+
+run `composer update` to remove ignored dependencies from lock file.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
     },
 
     "extra": {
-        "class": "Pro\\Composer\\SwDependencySolver\\Plugin"
+        "class": "Pro\\Composer\\DependencyIgnore\\Plugin"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a98aa633522a3e286b0d148d1b2c389e",
+    "content-hash": "74b7ef8271b8ded0a1468d44b988add1",
     "packages": [],
     "packages-dev": [
         {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,5 @@
 parameters:
     bootstrapFiles:
-        - ../../../vendor/autoload.php
     scanDirectories:
-        - ../../../src/
     level: 6
     ignoreErrors:

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Pro\Composer\DependencyIgnore;
+
+use Exception;
+use ReflectionProperty;
+
+use Composer\Composer;
+use Composer\DependencyResolver\Request;
+
+use Composer\IO\IOInterface;
+use Composer\Package\Link;
+use Composer\Package\PackageInterface;
+
+use Composer\Plugin\PluginInterface;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PrePoolCreateEvent;
+
+use Composer\Semver\Constraint\ConstraintInterface;
+
+class Plugin implements PluginInterface, EventSubscriberInterface {
+
+    protected Composer $composer;
+    protected IOInterface $io;
+
+    /**
+     * @var string[]
+     */
+    protected array $rootDependencies;
+
+    function activate(Composer $composer, IOInterface $io): void {
+        $this->composer = $composer;
+        $this->io = $io;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    function deactivate(Composer $composer, IOInterface $io): void {}
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    function uninstall(Composer $composer, IOInterface $io): void {}
+
+    function onFilterDependencies(PrePoolCreateEvent $event): void {
+        $rootPackage = $this->composer->getPackage();
+        $extras = $rootPackage->getExtra();
+        $ignoreList = $extras['ignore'];
+
+        $requestRequires = [];
+
+        foreach ($event->getRequest()->getRequires() as $key => $value) {
+            if (in_array($key, $ignoreList)) {
+                continue;
+            }
+
+            $requestRequires[$key] = $value;
+        }
+
+
+        $rf = new ReflectionProperty(Request::class, 'requires');
+        $rf->setAccessible(true);
+        $rf->setValue($event->getRequest(), $requestRequires);
+
+        $requires = [];
+
+        foreach ($rootPackage->getRequires() as $key => $package) {
+            if (in_array($package->getTarget(), $ignoreList)) {
+                continue;
+            }
+
+            $requires[$key] = $package;
+        }
+
+        $rootPackage->setRequires($requires);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    static function getSubscribedEvents(): array {
+        return [
+            PluginEvents::PRE_POOL_CREATE => 'onFilterDependencies',
+        ];
+    }
+}


### PR DESCRIPTION
Initial implementation of the composer plugin. This allows a composer project to specify which packages should be ignored during composer `install` and `update`.

We mainly need this to ignore the shopware dependency inside shopware 6 plugins. We also need to ignore dependencies to other Shopware 6 plugins on which me might rely.